### PR TITLE
Dev

### DIFF
--- a/src/main/java/com/nexaworks/rafiq/dto/request/TestResultRequest.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/request/TestResultRequest.java
@@ -7,6 +7,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-public record TestResultRequest(@NotBlank String name, @NotNull UUID id, Date date, List<TestRequest> tests,UUID testId) {
+public record TestResultRequest(@NotBlank String name, Date date, List<TestRequest> tests,UUID testId) {
 
 }

--- a/src/main/java/com/nexaworks/rafiq/dto/response/TestResponse.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/response/TestResponse.java
@@ -7,8 +7,6 @@ import java.util.Date;
 import java.util.UUID;
 
 public record TestResponse(String name,
-                           UUID labId,
-                           String labName,
                            UUID testId,
                            String fileUrl,
                            String fileType) {

--- a/src/main/java/com/nexaworks/rafiq/dto/response/TestResultsResponse.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/response/TestResultsResponse.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record TestResultsResponse(String name,
-                                  UUID labId,
-                                  String labName,
                                   UUID testId,
                                   String fileUrl,
                                   String fileType,

--- a/src/main/java/com/nexaworks/rafiq/mapper/PageMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/PageMapper.java
@@ -36,8 +36,6 @@ public class PageMapper {
         List<TestResponse> content = all.getContent().stream()
                 .map(labTest -> new TestResponse(
                         labTest.getName(),
-                        labTest.getLab().getId(),
-                        labTest.getLab().getName(),
                         labTest.getId(),
                         labTest.getPdf(),
                         labTest.getFileType()

--- a/src/main/java/com/nexaworks/rafiq/mapper/TestMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/TestMapper.java
@@ -17,8 +17,6 @@ public class TestMapper {
     public TestResultsResponse mapToTestResponse(LabTest test) {
         return new TestResultsResponse(
                 test.getName(),
-                test.getLab().getId(),
-                test.getLab().getName(),
                 test.getId(),
                 test.getPdf(),
                 test.getFileType(),

--- a/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/LabTestServiceImpl.java
+++ b/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/LabTestServiceImpl.java
@@ -48,10 +48,10 @@ public class LabTestServiceImpl implements LabTestService {
         setTestFields(labTest, testResultRequest, Instant.now());
         PatientProfile patient = getPatientProfile();
         labTest.setPatient(patient);
-        Lab lab = getLab(testResultRequest);
-        lab.getTests().add(labTest);
-        lab = labService.save(lab);
-        labTest.setLab(lab);
+//        Lab lab = getLab(testResultRequest);
+//        lab.getTests().add(labTest);
+//        lab = labService.save(lab);
+//        labTest.setLab(lab);
         labTestRepository.save(labTest);
         entity.forEach(e -> e.setLabTest(labTest));
         labResultService.saveAll(entity);
@@ -62,10 +62,10 @@ public class LabTestServiceImpl implements LabTestService {
         return userService.getUser().getPatientProfile();
     }
 
-    private Lab getLab(TestResultRequest testResultRequest) {
-        return labService.getLabById(testResultRequest.id())
-                .orElseThrow(() -> new LabException("Invalid Lab Id"));
-    }
+//    private Lab getLab(TestResultRequest testResultRequest) {
+//        return labService.getLabById(testResultRequest.id())
+//                .orElseThrow(() -> new LabException("Invalid Lab Id"));
+//    }
 
 
     private static void setTestFields(LabTest labTest, TestResultRequest testResultRequest, Instant now) {
@@ -122,7 +122,7 @@ public class LabTestServiceImpl implements LabTestService {
         LabTest test = validateOwnership(testId);
         updateTestFields(testResultRequest, test);
         updateLabResults(entity, test);
-        updateLabAssociation(testResultRequest, test);
+//        updateLabAssociation(testResultRequest, test);
         labTestRepository.save(test);
     }
 
@@ -136,19 +136,19 @@ public class LabTestServiceImpl implements LabTestService {
     }
 
 
-    private void updateLabAssociation(TestResultRequest testResultRequest, LabTest test) {
-        Lab lab = test.getLab();
-        if (lab.getId()!= testResultRequest.id()) {
-            Optional<Lab> labOptional = labService.getLabById(testResultRequest.id());
-            if (labOptional.isPresent()) {
-                lab = labOptional.get();
-                lab.getTests().add(test);
-                test.setLab(lab);
-            } else {
-                throw new LabException("Invalid Lab Id");
-            }
-        }
-    }
+//    private void updateLabAssociation(TestResultRequest testResultRequest, LabTest test) {
+//        Lab lab = test.getLab();
+//        if (lab.getId()!= testResultRequest.id()) {
+//            Optional<Lab> labOptional = labService.getLabById(testResultRequest.id());
+//            if (labOptional.isPresent()) {
+//                lab = labOptional.get();
+//                lab.getTests().add(test);
+//                test.setLab(lab);
+//            } else {
+//                throw new LabException("Invalid Lab Id");
+//            }
+//        }
+//    }
 
     private static void updateTestFields(TestResultRequest testResultRequest, LabTest test) {
         setTestFields(test, testResultRequest, test.getDate());


### PR DESCRIPTION
This pull request refactors how lab associations are handled in test result requests and responses. The main change is the removal of the lab ID and lab name from several DTOs and the deprecation of code that managed lab associations when adding or updating test results. This simplifies the data model and related service logic.

### DTO and Data Model Simplification

* Removed the `id` (lab ID) field from the `TestResultRequest` record, so lab information is no longer required when creating or updating test results.
* Removed `labId` and `labName` fields from the `TestResponse` and `TestResultsResponse` records, so API responses no longer include lab details for tests. [[1]](diffhunk://#diff-12c7721259015e5ef058fd649dbe3d877523e6af51bb5e8b7eefd14e6bb28285L10-L11) [[2]](diffhunk://#diff-24f3e291aaf8361a96ccd3cb8be01eb5fe3dc34626cde2a9a31b82d1e4029e15L11-L12)
* Updated the `PageMapper` and `TestMapper` to reflect the new structure of `TestResponse` and `TestResultsResponse`, removing references to lab information. [[1]](diffhunk://#diff-b286c71837ffa747fee1bb6d77f55b9e10ff5fd746f03f185b349fbe9ef9d206L39-L40) [[2]](diffhunk://#diff-be252ef383c6975d67d7096414b1c511a7d2531729e01b8ec5b7f082ad101680L20-L21)

### Service Logic Changes

* Commented out (deprecated) the logic in `LabTestServiceImpl` that previously associated a test with a lab when adding or updating test results, including the methods and calls to fetch and set the lab. This means lab associations are no longer updated or validated as part of these operations. [[1]](diffhunk://#diff-59808d32ce63be378055a23681150c17b2c94edefec088e9497ef78831c45c2fL51-R54) [[2]](diffhunk://#diff-59808d32ce63be378055a23681150c17b2c94edefec088e9497ef78831c45c2fL65-R68) [[3]](diffhunk://#diff-59808d32ce63be378055a23681150c17b2c94edefec088e9497ef78831c45c2fL125-R125) [[4]](diffhunk://#diff-59808d32ce63be378055a23681150c17b2c94edefec088e9497ef78831c45c2fL139-R151)