### PR TITLE
feat: replace OTP with access token for forget password flow and upda…

### DIFF
--- a/src/main/java/com/nexaworks/rafiq/controller/AuthController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/AuthController.java
@@ -11,9 +11,7 @@ import com.nexaworks.rafiq.dto.request.auth.OAuthRequest;
 import com.nexaworks.rafiq.dto.request.user.ChangePasswordRequest;
 import com.nexaworks.rafiq.dto.request.user.ForgetPasswordRequest;
 import com.nexaworks.rafiq.dto.request.user.ResetPasswordRequest;
-import com.nexaworks.rafiq.dto.request.user.VerifyOtpRequest;
 import com.nexaworks.rafiq.dto.response.auth.LoginResponse;
-import com.nexaworks.rafiq.dto.response.auth.VerifyOtpResponse;
 import com.nexaworks.rafiq.service.AuthService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,12 +32,6 @@ public class AuthController {
             @RequestBody @Valid ForgetPasswordRequest forgetPasswordRequest) {
         authService.forgetPassword(forgetPasswordRequest);
         return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/verify")
-    public ResponseEntity<VerifyOtpResponse> verify(
-            @RequestBody @Valid VerifyOtpRequest verifyOtpRequest) {
-        return ResponseEntity.ok().body(authService.verifyOtp(verifyOtpRequest));
     }
 
     @PostMapping("/change-password")

--- a/src/main/java/com/nexaworks/rafiq/dto/event/ForgetPasswordEvent.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/event/ForgetPasswordEvent.java
@@ -1,4 +1,4 @@
 package com.nexaworks.rafiq.dto.event;
 
-public record ForgetPasswordEvent(String email, String otp, String name) {
+public record ForgetPasswordEvent(String email, String accessToken, String name) {
 }

--- a/src/main/java/com/nexaworks/rafiq/eventListener/NotificationListener.java
+++ b/src/main/java/com/nexaworks/rafiq/eventListener/NotificationListener.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationListener {
+    public static final String FORGET_PASSWORD_URL = "http://localhost:5173/update-password";
     private final EmailContentService emailContentService;
     private final EmailSenderService emailSenderService;
     private final ImageService imageService;
@@ -35,7 +36,6 @@ public class NotificationListener {
     public void handleUserRegistrationEvent(UserRegistrationEvent event) {
         Map<String, Object> model = emailContentService.createOtpEmail(event.otp(), event.name(),
                 "url");
-        log.info("Sending email to {}", event.email());
         emailSenderService.sendEmail(model, event.email(), "Verify your email address",
                 "OTP_TEMPLATE.html");
     }
@@ -45,16 +45,14 @@ public class NotificationListener {
     public void handleNewOtpEvent(NewOtpEvent event) {
         Map<String, Object> model = emailContentService.createOtpEmail(event.otp(), event.name(),
                 "url");
-        log.info("Sending email to {}", event.email());
         emailSenderService.sendEmail(model, event.email(), "New OTP", "new-otp.html");
     }
 
     @Async
     @EventListener
     public void handleForgetPasswordEvent(ForgetPasswordEvent event) {
-        Map<String, Object> model = emailContentService.createOtpEmail(event.otp(), event.name(),
-                "url");
-        log.info("Sending email to {}", event.email());
+        Map<String, Object> model = emailContentService
+                .createResetPasswordEmail(event.accessToken(), event.name(), FORGET_PASSWORD_URL);
         emailSenderService.sendEmail(model, event.email(), "Reset your password",
                 "forget-password.html");
     }

--- a/src/main/java/com/nexaworks/rafiq/service/EmailContentService.java
+++ b/src/main/java/com/nexaworks/rafiq/service/EmailContentService.java
@@ -4,4 +4,6 @@ import java.util.Map;
 
 public interface EmailContentService {
     Map<String, Object> createOtpEmail(String otp, String name, String url);
+
+    Map<String, Object> createResetPasswordEmail(String s, String name, String url);
 }

--- a/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/AuthServiceImpl.java
+++ b/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/AuthServiceImpl.java
@@ -58,9 +58,10 @@ public class AuthServiceImpl implements AuthService {
         if (user.isEmpty()) {
             return;
         }
-        String otp = tokenService.generateOtpToken(user.get());
-        log.info("Generated OTP {}", otp);
-        eventPublisher.publishEvent(new ForgetPasswordEvent(email, otp, user.get().getFirstName()));
+        String token = tokenService.generateAccessToken(user);
+        log.info("Generated OTP {}", token);
+        eventPublisher
+                .publishEvent(new ForgetPasswordEvent(email, token, user.get().getFirstName()));
     }
 
     @Override

--- a/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/EmailContentServiceImpl.java
+++ b/src/main/java/com/nexaworks/rafiq/service/ServiceImpl/EmailContentServiceImpl.java
@@ -18,4 +18,10 @@ public class EmailContentServiceImpl implements EmailContentService {
     public Map<String, Object> createOtpEmail(String otp, String name, String url) {
         return Map.of("otp", otp, "name", name, "url", url);
     }
+
+    @Override
+    public Map<String, Object> createResetPasswordEmail(String accessToken, String name,
+            String url) {
+        return Map.of("name", name, "url", url + "?token=" + accessToken);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
    # JPA config
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
       show-sql: true
     defer-datasource-initialization: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/templates/forget-password.html
+++ b/src/main/resources/templates/forget-password.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Password Reset</title>
+    <title>Forgot Password</title>
     <style>
         body {
             margin: 0;
@@ -84,15 +84,15 @@
 <div class="email-container">
     <div class="header">
         <img src="https://via.placeholder.com/120x50?text=Logo" alt="Company Logo">
-        <h1>Password Reset Request</h1>
+        <h1>Forgot Your Password?</h1>
     </div>
     <div class="body">
-        <h2>Hello, <span th:text="${name}">Name</span></h2>
-        <p>We received a request to reset your password. Use the OTP below to reset it. This OTP is valid for a limited time.</p>
+        <h2>Hi <span th:text="${name}">Name</span>,</h2>
+        <p>We received a request to reset your password. Use the OTP below to create a new password. This OTP is valid for 30 minutes.</p>
         <div class="otp" th:text="${otp}">123456</div>
-        <p>Or you can click the button below to reset your password directly:</p>
+        <p>Or click the button below to reset your password:</p>
         <a th:href="${url}" class="button">Reset Password</a>
-        <p>If you did not request a password reset, please ignore this email.</p>
+        <p><strong>Didn't request this?</strong> If you didn't ask to reset your password, you can safely ignore this email. Your account remains secure.</p>
     </div>
     <div class="footer">
         &copy; 2025 Your Company. All rights reserved.

--- a/src/test/java/com/nexaworks/rafiq/integration/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/nexaworks/rafiq/integration/controller/AuthControllerIntegrationTest.java
@@ -24,7 +24,6 @@ import com.nexaworks.rafiq.dto.request.auth.LoginRequest;
 import com.nexaworks.rafiq.dto.request.user.ChangePasswordRequest;
 import com.nexaworks.rafiq.dto.request.user.ForgetPasswordRequest;
 import com.nexaworks.rafiq.dto.request.user.ResetPasswordRequest;
-import com.nexaworks.rafiq.dto.request.user.VerifyOtpRequest;
 import com.nexaworks.rafiq.entities.Role;
 import com.nexaworks.rafiq.entities.Token;
 import com.nexaworks.rafiq.entities.User;
@@ -111,7 +110,7 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
         class ShouldProcessForgetPasswordSuccessfully {
 
             @Test
-            @DisplayName("Should generate OTP and return 200 OK when user exists")
+            @DisplayName("Should generate AccessToken and return 200 OK when user exists")
             void shouldGenerateOtpAndReturnOkWhenUserExists() throws Exception {
                 // Arrange - Create a test user directly
                 String email = "forget.password@example.com";
@@ -120,7 +119,7 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Get the initial OTP count
                 long initialOtpCount = tokenRepository.findAll().stream()
                         .filter(t -> t.getUser().getId().equals(user.getId()))
-                        .filter(t -> t.getTokenType().equals(TokenType.OTP)).count();
+                        .filter(t -> t.getTokenType().equals(TokenType.ACCESS_TOKEN)).count();
 
                 // Prepare forget password request
                 ForgetPasswordRequest forgetPasswordRequest = new ForgetPasswordRequest(email);
@@ -135,7 +134,7 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Verify new OTP was generated using AssertJ
                 long newOtpCount = tokenRepository.findAll().stream()
                         .filter(t -> t.getUser().getId().equals(user.getId()))
-                        .filter(t -> t.getTokenType().equals(TokenType.OTP)).count();
+                        .filter(t -> t.getTokenType().equals(TokenType.ACCESS_TOKEN)).count();
 
                 assertThat(newOtpCount).isGreaterThan(initialOtpCount)
                         .as("New OTP should be generated for forget password");
@@ -244,120 +243,6 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Verify no OTP was generated using AssertJ
                 assertThat(tokenRepository.count()).isZero()
                         .as("No token should be created for whitespace email");
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("Verify OTP")
-    class VerifyOtp {
-        private final String VERIFY_OTP_ENDPOINT = "/auth/verify";
-
-        @Nested
-        @DisplayName("Should Verify OTP Successfully")
-        class ShouldVerifyOtpSuccessfully {
-
-            @Test
-            @DisplayName("Should verify OTP and return access token when OTP is valid")
-            void shouldVerifyOtpAndReturnAccessTokenWhenOtpIsValid() throws Exception {
-                // Arrange - Create user and OTP token directly
-                String email = "verify.user@example.com";
-                User user = createTestUser(email, "Valid@1234", "Jane", "Smith");
-
-                String otpValue = "123456";
-                Instant expiryDate = Instant.now().plus(15, ChronoUnit.MINUTES);
-                createOtpToken(user, otpValue, expiryDate);
-
-                // Prepare verify OTP request
-                VerifyOtpRequest verifyRequest = new VerifyOtpRequest(email, otpValue);
-                String payload = objectMapper.writeValueAsString(verifyRequest);
-
-                // Act & Assert - Verify OTP
-                mockMvc.perform(MockMvcRequestBuilders.post(VERIFY_OTP_ENDPOINT)
-                        .contentType(MediaType.APPLICATION_JSON).content(payload))
-                        .andExpect(MockMvcResultMatchers.status().isOk())
-                        .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken").exists());
-            }
-        }
-
-        @Nested
-        @DisplayName("Should Fail Verifying OTP")
-        class ShouldFailVerifyingOtp {
-
-            @Test
-            @DisplayName("Should return 404 Not Found when OTP does not exist")
-            void shouldReturnNotFoundWhenOtpDoesNotExist() throws Exception {
-                // Arrange - Create user but no OTP token
-                String email = "no.otp@example.com";
-                createTestUser(email, "Valid@1234", "John", "Doe");
-
-                String fakeOtp = "999999";
-                VerifyOtpRequest verifyRequest = new VerifyOtpRequest(email, fakeOtp);
-                String payload = objectMapper.writeValueAsString(verifyRequest);
-
-                // Act & Assert - Should return 404
-                mockMvc.perform(MockMvcRequestBuilders.post(VERIFY_OTP_ENDPOINT)
-                        .contentType(MediaType.APPLICATION_JSON).content(payload))
-                        .andExpect(MockMvcResultMatchers.status().isNotFound());
-            }
-
-            @Test
-            @DisplayName("Should return 401 unauthorized when OTP is expired")
-            void shouldReturnBadRequestWhenOtpIsExpired() throws Exception {
-                // Arrange - Create user and expired OTP token
-                String email = "expired.otp@example.com";
-                User user = createTestUser(email, "Valid@1234", "Bob", "Wilson");
-
-                String otpValue = "654321";
-                Instant expiredDate = Instant.now().minus(1, ChronoUnit.HOURS); // Expired 1 hour
-                                                                                // ago
-                createOtpToken(user, otpValue, expiredDate);
-
-                VerifyOtpRequest verifyRequest = new VerifyOtpRequest(email, otpValue);
-                String payload = objectMapper.writeValueAsString(verifyRequest);
-
-                // Act & Assert - Should return 400
-                mockMvc.perform(MockMvcRequestBuilders.post(VERIFY_OTP_ENDPOINT)
-                        .contentType(MediaType.APPLICATION_JSON).content(payload))
-                        .andExpect(MockMvcResultMatchers.status().isUnauthorized());
-            }
-
-            @Test
-            @DisplayName("Should return 401 unauthorized when email does not match OTP")
-            void shouldReturnBadRequestWhenEmailDoesNotMatchOtp() throws Exception {
-                // Arrange - Create user and OTP, but use different email
-                String correctEmail = "correct@example.com";
-                User user = createTestUser(correctEmail, "Valid@1234", "Alice", "Johnson");
-
-                String otpValue = "111222";
-                Instant expiryDate = Instant.now().plus(15, ChronoUnit.MINUTES);
-                createOtpToken(user, otpValue, expiryDate);
-
-                // Try to verify with wrong email
-                String wrongEmail = "wrong@example.com";
-                VerifyOtpRequest verifyRequest = new VerifyOtpRequest(wrongEmail, otpValue);
-                String payload = objectMapper.writeValueAsString(verifyRequest);
-
-                // Act & Assert - Should return 400
-                mockMvc.perform(MockMvcRequestBuilders.post(VERIFY_OTP_ENDPOINT)
-                        .contentType(MediaType.APPLICATION_JSON).content(payload))
-                        .andExpect(MockMvcResultMatchers.status().isUnauthorized());
-            }
-
-            @Test
-            @DisplayName("Should return 400 Bad Request when OTP format is invalid (validation)")
-            void shouldReturnBadRequestForInvalidOtpFormat() throws Exception {
-                // Arrange
-                String email = "test@example.com";
-                String invalidOtp = "12345"; // Only 5 digits, should be 6
-
-                VerifyOtpRequest verifyRequest = new VerifyOtpRequest(email, invalidOtp);
-                String payload = objectMapper.writeValueAsString(verifyRequest);
-
-                // Act & Assert - Should return 400 for validation error
-                mockMvc.perform(MockMvcRequestBuilders.post(VERIFY_OTP_ENDPOINT)
-                        .contentType(MediaType.APPLICATION_JSON).content(payload))
-                        .andExpect(MockMvcResultMatchers.status().isBadRequest());
             }
         }
     }
@@ -503,9 +388,9 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Act & Assert - Reset password with authentication
                 mockMvc.perform(MockMvcRequestBuilders.post(RESET_PASSWORD_ENDPOINT)
                         .contentType(MediaType.APPLICATION_JSON).content(payload).with(user(user))) // Authenticate
-                                                                                                    // as
-                                                                                                    // this
-                                                                                                    // user
+                        // as
+                        // this
+                        // user
                         .andExpect(MockMvcResultMatchers.status().isNoContent());
 
                 // Verify password was changed
@@ -554,9 +439,9 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Act & Assert - Should return 400 for incorrect old password
                 mockMvc.perform(MockMvcRequestBuilders.post(RESET_PASSWORD_ENDPOINT)
                         .contentType(MediaType.APPLICATION_JSON).content(payload).with(user(user))) // Authenticate
-                                                                                                    // as
-                                                                                                    // this
-                                                                                                    // user
+                        // as
+                        // this
+                        // user
                         .andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
                 // Verify password was NOT changed
@@ -581,9 +466,9 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
                 // Act & Assert - Should return 400 for validation error
                 mockMvc.perform(MockMvcRequestBuilders.post(RESET_PASSWORD_ENDPOINT)
                         .contentType(MediaType.APPLICATION_JSON).content(payload).with(user(user))) // Authenticate
-                                                                                                    // as
-                                                                                                    // this
-                                                                                                    // user
+                        // as
+                        // this
+                        // user
                         .andExpect(MockMvcResultMatchers.status().isBadRequest());
 
                 // Verify password was NOT changed

--- a/src/test/java/com/nexaworks/rafiq/unit/service/AuthServiceImplTest.java
+++ b/src/test/java/com/nexaworks/rafiq/unit/service/AuthServiceImplTest.java
@@ -127,19 +127,20 @@ class AuthServiceImplTest {
             String generatedOtp = "123456";
 
             when(userService.findByEmail(request.email())).thenReturn(Optional.of(testUser));
-            when(tokenService.generateOtpToken(testUser)).thenReturn(generatedOtp);
+            when(tokenService.generateAccessToken(Optional.ofNullable(testUser)))
+                    .thenReturn(generatedOtp);
 
             // Act
             authService.forgetPassword(request);
 
             // Assert
             verify(userService).findByEmail(request.email());
-            verify(tokenService).generateOtpToken(testUser);
+            verify(tokenService).generateAccessToken(Optional.ofNullable(testUser));
             verify(eventPublisher).publishEvent(eventCaptor.capture());
 
             ForgetPasswordEvent capturedEvent = eventCaptor.getValue();
             assertThat(capturedEvent.email()).isEqualTo(testUser.getEmail());
-            assertThat(capturedEvent.otp()).isEqualTo(generatedOtp);
+            assertThat(capturedEvent.accessToken()).isEqualTo(generatedOtp);
             assertThat(capturedEvent.name()).isEqualTo(testUser.getFirstName());
         }
 


### PR DESCRIPTION
This pull request refactors the "Forgot Password" flow to use access tokens instead of OTPs, removes the OTP verification endpoint, and updates related email content and tests. The main changes streamline the password reset process by sending a reset link with an access token, rather than requiring users to enter an OTP.

**Password Reset Flow Refactor:**

* The "forget password" process now generates and emails an access token (used as a reset link), replacing the previous OTP-based approach. (`AuthServiceImpl.java`, `ForgetPasswordEvent.java`, `NotificationListener.java`, `EmailContentService.java`, `EmailContentServiceImpl.java`, `forget-password.html`, `application.yml`) [[1]](diffhunk://#diff-786d4eec383efb927033f9e2b69549baf9998a2f07a5226e2971919a94aa39bcL61-R64) [[2]](diffhunk://#diff-a58a275786872844979f361e84bc675f9763708e3247694dc06dfa3f64dcb4acL3-R3) [[3]](diffhunk://#diff-4eddb62d547af365184eeee78d46d582b1ced14bea5d639a32635f837b66fc08L48-R55) [[4]](diffhunk://#diff-313bce3f09c26b3969f8218417af4821b1ed1d76fcbb0af099d93214ef48939eR7-R8) [[5]](diffhunk://#diff-9ff9dd2f32298803c8830f8f4874cf6a77f1feaea45b6767f60b00bf53d87114R21-R26) [[6]](diffhunk://#diff-6650bec9454f2abc1b8d9a4bb215224581c584eed5163d6cb79ad3c103c26a24L87-R95) [[7]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dL16-R16)

* The email template and sending logic were updated to remove OTP references and provide a direct reset link with the access token. (`NotificationListener.java`, `forget-password.html`) [[1]](diffhunk://#diff-4eddb62d547af365184eeee78d46d582b1ced14bea5d639a32635f837b66fc08L48-R55) [[2]](diffhunk://#diff-6650bec9454f2abc1b8d9a4bb215224581c584eed5163d6cb79ad3c103c26a24L87-R95)

**API and Test Cleanup:**

* The `/auth/verify` OTP verification endpoint and all related DTOs, responses, and integration tests were removed, as the flow no longer requires OTP verification. (`AuthController.java`, `AuthControllerIntegrationTest.java`) [[1]](diffhunk://#diff-cedb73c72af70cf9f6ca270eff167b6f7323048b68167e238b46cebb8ed6faa6L39-L44) [[2]](diffhunk://#diff-a7109216d9b8865ab9443dae93f2f7315562dd2188bd42d8f7c784073cde8286L251-L364)

* Tests and supporting code now expect access tokens rather than OTPs for password reset, including updates to test descriptions and token type assertions. (`AuthControllerIntegrationTest.java`, `AuthServiceImplTest.java`) [[1]](diffhunk://#diff-a7109216d9b8865ab9443dae93f2f7315562dd2188bd42d8f7c784073cde8286L114-R113) [[2]](diffhunk://#diff-a7109216d9b8865ab9443dae93f2f7315562dd2188bd42d8f7c784073cde8286L123-R122) [[3]](diffhunk://#diff-a7109216d9b8865ab9443dae93f2f7315562dd2188bd42d8f7c784073cde8286L138-R137) [[4]](diffhunk://#diff-5dc81060d592fa06e96e7b2844849fd0e0f712b2318fb7369e4568cf6356b798L130-R143)

**Other:**

* Changed Hibernate DDL auto mode to `create-drop` for development purposes. (`application.yml`)…te related tests