### PR TITLE
Feat/add consultation summary

### DIFF
--- a/src/main/java/com/nexaworks/rafiq/controller/ConsultationSummaryController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ConsultationSummaryController.java
@@ -1,0 +1,67 @@
+package com.nexaworks.rafiq.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import com.nexaworks.rafiq.dto.request.summary.CreateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.response.common.PageResponse;
+import com.nexaworks.rafiq.dto.response.summary.ConsultationSummaryResponse;
+import com.nexaworks.rafiq.entities.enums.Specialization;
+import com.nexaworks.rafiq.service.summary.ConsultationSummaryService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/consultation-summary")
+@RequiredArgsConstructor
+@Tag(name = "Consultation summary", description = "Post-consultation summaries")
+public class ConsultationSummaryController {
+
+    private final ConsultationSummaryService consultationSummaryService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('DOCTOR')")
+    public ResponseEntity<ConsultationSummaryResponse> create(
+            @Valid @RequestBody CreateConsultationSummaryRequest request) {
+        return ResponseEntity.ok(consultationSummaryService.create(request));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('PATIENT','DOCTOR')")
+    public ResponseEntity<ConsultationSummaryResponse> get(@PathVariable UUID id) {
+        return ResponseEntity.ok(consultationSummaryService.get(id));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('DOCTOR')")
+    public ResponseEntity<ConsultationSummaryResponse> update(@PathVariable UUID id,
+            @RequestBody UpdateConsultationSummaryRequest request) {
+        return ResponseEntity.ok(consultationSummaryService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('PATIENT','DOCTOR')")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        consultationSummaryService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('PATIENT','DOCTOR')")
+    public ResponseEntity<PageResponse<ConsultationSummaryResponse>> list(
+            @RequestParam(required = false) UUID patientId,
+            @RequestParam(required = false) Specialization specialization, Pageable pageable) {
+        Page<ConsultationSummaryResponse> page = consultationSummaryService.list(patientId,
+                specialization, pageable);
+        return ResponseEntity.ok(new PageResponse<>(page.getContent(), page.getNumberOfElements(),
+                page.getSize(), page.getTotalPages(), page.isLast(), page.isFirst()));
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/dto/request/summary/ConsultationSummaryFilter.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/request/summary/ConsultationSummaryFilter.java
@@ -1,0 +1,6 @@
+package com.nexaworks.rafiq.dto.request.summary;
+
+import com.nexaworks.rafiq.entities.enums.Specialization;
+
+public record ConsultationSummaryFilter(Specialization specialization) {
+}

--- a/src/main/java/com/nexaworks/rafiq/dto/request/summary/CreateConsultationSummaryRequest.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/request/summary/CreateConsultationSummaryRequest.java
@@ -1,0 +1,12 @@
+package com.nexaworks.rafiq.dto.request.summary;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.nexaworks.rafiq.entities.MedicineSummary;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateConsultationSummaryRequest(@NotNull UUID consultationId, String summary,
+        String recoveryPlan, List<MedicineSummary> medicineSummary, List<String> requiredLabTest) {
+}

--- a/src/main/java/com/nexaworks/rafiq/dto/request/summary/UpdateConsultationSummaryRequest.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/request/summary/UpdateConsultationSummaryRequest.java
@@ -1,0 +1,9 @@
+package com.nexaworks.rafiq.dto.request.summary;
+
+import java.util.List;
+
+import com.nexaworks.rafiq.entities.MedicineSummary;
+
+public record UpdateConsultationSummaryRequest(String summary, String recoveryPlan,
+        List<MedicineSummary> medicineSummary, List<String> requiredLabTest) {
+}

--- a/src/main/java/com/nexaworks/rafiq/dto/response/summary/ConsultationSummaryResponse.java
+++ b/src/main/java/com/nexaworks/rafiq/dto/response/summary/ConsultationSummaryResponse.java
@@ -1,0 +1,11 @@
+package com.nexaworks.rafiq.dto.response.summary;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.nexaworks.rafiq.entities.MedicineSummary;
+
+public record ConsultationSummaryResponse(UUID id, UUID consultationId, UUID doctorId,
+        UUID patientId, String summary, String recoveryPlan, List<MedicineSummary> medicineSummary,
+        List<String> requiredLabTest) {
+}

--- a/src/main/java/com/nexaworks/rafiq/entities/Consultation.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/Consultation.java
@@ -50,6 +50,9 @@ public class Consultation extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Specialization specialization;
 
+    @OneToOne(mappedBy = "consultation")
+    private ConsultationSummary consultationSummary;
+
     @Transient
     public boolean isCancelled() {
         return status == ConsultationStatus.CANCELLED;

--- a/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
@@ -1,0 +1,37 @@
+package com.nexaworks.rafiq.entities;
+
+import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConsultationSummary extends BaseEntity {
+    private String summary;
+    private String recoveryPlan;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<MedicineSummary> medicineSummary;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private List<String> requiredLabTests;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "doctor_id", referencedColumnName = "id")
+    private Doctor doctor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "patient_id", referencedColumnName = "id")
+    private Patient patient;
+
+}

--- a/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
@@ -24,7 +24,7 @@ public class ConsultationSummary extends BaseEntity {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
-    private List<String> requiredLabTests;
+    private List<String> requiredLabTest;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "doctor_id", referencedColumnName = "id")

--- a/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java
@@ -7,15 +7,21 @@ import org.hibernate.type.SqlTypes;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Entity
+@Table(name = "consultation_summary")
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 public class ConsultationSummary extends BaseEntity {
+
+    @Column(columnDefinition = "TEXT")
     private String summary;
+
+    @Column(columnDefinition = "TEXT")
     private String recoveryPlan;
 
     @JdbcTypeCode(SqlTypes.JSON)
@@ -26,12 +32,15 @@ public class ConsultationSummary extends BaseEntity {
     @Column(columnDefinition = "jsonb")
     private List<String> requiredLabTest;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "doctor_id", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "doctor_id", referencedColumnName = "id", nullable = false)
     private Doctor doctor;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "patient_id", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "patient_id", referencedColumnName = "id", nullable = false)
     private Patient patient;
 
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "consultation_id", referencedColumnName = "id", nullable = false, unique = true)
+    private Consultation consultation;
 }

--- a/src/main/java/com/nexaworks/rafiq/entities/Medicine.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/Medicine.java
@@ -64,10 +64,6 @@ public class Medicine extends BaseEntity {
     private Drug drug;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "doctor_id", referencedColumnName = "id")
-    private Doctor doctor;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "patient_id", referencedColumnName = "id", nullable = false)
     private Patient patient;
 

--- a/src/main/java/com/nexaworks/rafiq/entities/Medicine.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/Medicine.java
@@ -18,8 +18,7 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Table(name = "medicine", indexes = {
         @Index(columnList = "search_vector", name = "medicine_search_vector_idx"),
-        @Index(columnList = "patient_id", name = "patient_medicine_idx"),
-        @Index(columnList = "doctor_id", name = "doctor_medicine_idx")})
+        @Index(columnList = "patient_id", name = "patient_medicine_idx")})
 public class Medicine extends BaseEntity {
 
     @NotNull

--- a/src/main/java/com/nexaworks/rafiq/entities/MedicineSummary.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/MedicineSummary.java
@@ -1,0 +1,21 @@
+package com.nexaworks.rafiq.entities;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MedicineSummary {
+    private UUID drugId;
+    private String name;
+    private String dosage;
+}

--- a/src/main/java/com/nexaworks/rafiq/entities/MedicineSummary.java
+++ b/src/main/java/com/nexaworks/rafiq/entities/MedicineSummary.java
@@ -18,4 +18,5 @@ public class MedicineSummary {
     private UUID drugId;
     private String name;
     private String dosage;
+    private String frequency;
 }

--- a/src/main/java/com/nexaworks/rafiq/mapper/ConsultationMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/ConsultationMapper.java
@@ -75,7 +75,7 @@ public interface ConsultationMapper {
     @Mapping(target = "doctorImage", source = "doctor.personalPhoto")
     @Mapping(target = "startTime", source = "timeSlot.startTime")
     @Mapping(target = "duration", source = "timeSlot.durationMinutes")
-    @Mapping(target = "summaryId", ignore = true)
+    @Mapping(target = "summaryId", expression = "java(consultation.getSummary() != null ? consultation.getSummary().getId() : null)")
     PatientConsultationResponse toPatientDto(Consultation consultation);
 
     default List<PatientConsultationResponse> toPatientDtoList(List<Consultation> consultations) {

--- a/src/main/java/com/nexaworks/rafiq/mapper/ConsultationMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/ConsultationMapper.java
@@ -75,7 +75,7 @@ public interface ConsultationMapper {
     @Mapping(target = "doctorImage", source = "doctor.personalPhoto")
     @Mapping(target = "startTime", source = "timeSlot.startTime")
     @Mapping(target = "duration", source = "timeSlot.durationMinutes")
-    @Mapping(target = "summaryId", expression = "java(consultation.getSummary() != null ? consultation.getSummary().getId() : null)")
+    @Mapping(target = "summaryId", expression = "java(consultation.getConsultationSummary() != null ? consultation.getConsultationSummary().getId() : null)")
     PatientConsultationResponse toPatientDto(Consultation consultation);
 
     default List<PatientConsultationResponse> toPatientDtoList(List<Consultation> consultations) {

--- a/src/main/java/com/nexaworks/rafiq/mapper/ConsultationSummaryMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/ConsultationSummaryMapper.java
@@ -1,0 +1,50 @@
+package com.nexaworks.rafiq.mapper;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import com.nexaworks.rafiq.dto.request.summary.CreateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.response.summary.ConsultationSummaryResponse;
+import com.nexaworks.rafiq.entities.ConsultationSummary;
+
+@Mapper(componentModel = "spring")
+public interface ConsultationSummaryMapper {
+
+    @BeanMapping(ignoreUnmappedSourceProperties = "consultationId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "doctor", ignore = true)
+    @Mapping(target = "patient", ignore = true)
+    @Mapping(target = "consultation", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "updatedBy", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "deletedBy", ignore = true)
+    @Mapping(target = "deletedAt", ignore = true)
+    ConsultationSummary toEntity(CreateConsultationSummaryRequest request);
+
+    @Mapping(target = "consultationId", source = "consultation.id")
+    @Mapping(target = "doctorId", source = "doctor.id")
+    @Mapping(target = "patientId", source = "patient.id")
+    ConsultationSummaryResponse toResponse(ConsultationSummary entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "doctor", ignore = true)
+    @Mapping(target = "patient", ignore = true)
+    @Mapping(target = "consultation", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "updatedBy", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "deletedBy", ignore = true)
+    @Mapping(target = "deletedAt", ignore = true)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(UpdateConsultationSummaryRequest request,
+            @MappingTarget ConsultationSummary entity);
+}

--- a/src/main/java/com/nexaworks/rafiq/repository/ConsultationRepository.java
+++ b/src/main/java/com/nexaworks/rafiq/repository/ConsultationRepository.java
@@ -1,6 +1,7 @@
 package com.nexaworks.rafiq.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -81,4 +82,15 @@ public interface ConsultationRepository
     @Query("SELECT new com.nexaworks.rafiq.dto.response.consultation.DoctorConsultationResponse(c.id,c.timeSlot.startTime,c.timeSlot.endTime) FROM Consultation  c where c.doctor.id = :id AND c.status = :status")
     List<DoctorConsultationResponse> getDoctorAvailableConsultation(@Param("id") UUID id,
             @Param("status") ConsultationStatus consultationStatus);
+
+    @Query("""
+            SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END
+            FROM Consultation c
+            WHERE c.doctor.id = :doctorId
+            AND c.patient.id = :patientId
+            AND c.status NOT IN :excludedStatuses
+            """)
+    boolean existsByDoctorAndPatientAndStatusNotIn(@Param("doctorId") UUID doctorId,
+            @Param("patientId") UUID patientId,
+            @Param("excludedStatuses") Collection<ConsultationStatus> excludedStatuses);
 }

--- a/src/main/java/com/nexaworks/rafiq/repository/ConsultationSummaryRepository.java
+++ b/src/main/java/com/nexaworks/rafiq/repository/ConsultationSummaryRepository.java
@@ -1,0 +1,17 @@
+package com.nexaworks.rafiq.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import com.nexaworks.rafiq.entities.ConsultationSummary;
+
+public interface ConsultationSummaryRepository
+        extends
+            JpaRepository<ConsultationSummary, UUID>,
+            JpaSpecificationExecutor<ConsultationSummary> {
+
+    Optional<ConsultationSummary> findByConsultationId(UUID consultationId);
+}

--- a/src/main/java/com/nexaworks/rafiq/repository/specification/ConsultationSummarySpecification.java
+++ b/src/main/java/com/nexaworks/rafiq/repository/specification/ConsultationSummarySpecification.java
@@ -1,0 +1,29 @@
+package com.nexaworks.rafiq.repository.specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.nexaworks.rafiq.dto.request.summary.ConsultationSummaryFilter;
+import com.nexaworks.rafiq.entities.ConsultationSummary;
+
+import jakarta.persistence.criteria.Predicate;
+
+public class ConsultationSummarySpecification {
+
+    public static Specification<ConsultationSummary> filter(ConsultationSummaryFilter filter,
+            UUID patientId) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("patient").get("id"), patientId));
+
+            Optional.ofNullable(filter.specialization()).ifPresent(specialization -> predicates
+                    .add(cb.equal(root.get("doctor").get("specialization"), specialization)));
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/service/payment/PaymentTrackingService.java
+++ b/src/main/java/com/nexaworks/rafiq/service/payment/PaymentTrackingService.java
@@ -3,6 +3,7 @@ package com.nexaworks.rafiq.service.payment;
 import java.util.UUID;
 
 import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,16 +18,21 @@ import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class PaymentTrackingService implements IPaymentTrackingService {
     private final PaymentRepository paymentRepository;
     private final ConsultationService consultationService;
     private final PaymentScheduler paymentScheduler;
+
+    public PaymentTrackingService(PaymentRepository paymentRepository,
+            ConsultationService consultationService, @Lazy PaymentScheduler paymentScheduler) {
+        this.paymentRepository = paymentRepository;
+        this.consultationService = consultationService;
+        this.paymentScheduler = paymentScheduler;
+    }
 
     // TODO send notification to user
     @Override

--- a/src/main/java/com/nexaworks/rafiq/service/summary/ConsultationSummaryService.java
+++ b/src/main/java/com/nexaworks/rafiq/service/summary/ConsultationSummaryService.java
@@ -1,0 +1,25 @@
+package com.nexaworks.rafiq.service.summary;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.nexaworks.rafiq.dto.request.summary.CreateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.response.summary.ConsultationSummaryResponse;
+import com.nexaworks.rafiq.entities.enums.Specialization;
+
+public interface ConsultationSummaryService {
+
+    ConsultationSummaryResponse create(CreateConsultationSummaryRequest request);
+
+    ConsultationSummaryResponse get(UUID id);
+
+    ConsultationSummaryResponse update(UUID id, UpdateConsultationSummaryRequest request);
+
+    void delete(UUID id);
+
+    Page<ConsultationSummaryResponse> list(UUID patientId, Specialization specialization,
+            Pageable pageable);
+}

--- a/src/main/java/com/nexaworks/rafiq/service/summary/ConsultationSummaryServiceImpl.java
+++ b/src/main/java/com/nexaworks/rafiq/service/summary/ConsultationSummaryServiceImpl.java
@@ -1,0 +1,164 @@
+package com.nexaworks.rafiq.service.summary;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.nexaworks.rafiq.dto.request.summary.ConsultationSummaryFilter;
+import com.nexaworks.rafiq.dto.request.summary.CreateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.response.summary.ConsultationSummaryResponse;
+import com.nexaworks.rafiq.entities.Consultation;
+import com.nexaworks.rafiq.entities.ConsultationSummary;
+import com.nexaworks.rafiq.entities.User;
+import com.nexaworks.rafiq.entities.enums.ConsultationStatus;
+import com.nexaworks.rafiq.entities.enums.Specialization;
+import com.nexaworks.rafiq.mapper.ConsultationSummaryMapper;
+import com.nexaworks.rafiq.repository.ConsultationRepository;
+import com.nexaworks.rafiq.repository.ConsultationSummaryRepository;
+import com.nexaworks.rafiq.repository.specification.ConsultationSummarySpecification;
+import com.nexaworks.rafiq.service.authentication.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConsultationSummaryServiceImpl implements ConsultationSummaryService {
+
+    private static final List<ConsultationStatus> LIST_GATE_EXCLUDED_STATUSES = List
+            .of(ConsultationStatus.COMPLETED, ConsultationStatus.CANCELLED);
+
+    private final ConsultationSummaryRepository consultationSummaryRepository;
+    private final ConsultationRepository consultationRepository;
+    private final ConsultationSummaryMapper consultationSummaryMapper;
+    private final AuthService authService;
+
+    private static boolean hasAuthority(User user, String authority) {
+        return user.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals(authority));
+    }
+
+    @Override
+    @Transactional
+    public ConsultationSummaryResponse create(CreateConsultationSummaryRequest request) {
+        User user = authService.getAuthenticateUser();
+        UUID doctorId = user.getId();
+        Consultation consultation = consultationRepository.findById(request.consultationId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Consultation not found"));
+        if (consultation.getStatus() != ConsultationStatus.COMPLETED) {
+            throw new IllegalArgumentException(
+                    "Consultation must be completed before adding a summary");
+        }
+        if (!consultation.getDoctor().getId().equals(doctorId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You are not the doctor for this consultation");
+        }
+        if (consultation.getPatient() == null) {
+            throw new IllegalArgumentException("Consultation has no patient");
+        }
+        if (consultationSummaryRepository.findByConsultationId(consultation.getId()).isPresent()) {
+            throw new IllegalArgumentException("Summary already exists for this consultation");
+        }
+        ConsultationSummary entity = consultationSummaryMapper.toEntity(request);
+        entity.setDoctor(consultation.getDoctor());
+        entity.setPatient(consultation.getPatient());
+        entity.setConsultation(consultation);
+        return consultationSummaryMapper.toResponse(consultationSummaryRepository.save(entity));
+    }
+
+    @Override
+    public ConsultationSummaryResponse get(UUID id) {
+        ConsultationSummary summary = consultationSummaryRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Consultation summary not found"));
+        assertParticipantOrThrow(summary);
+        return consultationSummaryMapper.toResponse(summary);
+    }
+
+    @Override
+    @Transactional
+    public ConsultationSummaryResponse update(UUID id, UpdateConsultationSummaryRequest request) {
+        User user = authService.getAuthenticateUser();
+        ConsultationSummary summary = consultationSummaryRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Consultation summary not found"));
+        if (!summary.getDoctor().getId().equals(user.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Only the authoring doctor can update this summary");
+        }
+        consultationSummaryMapper.updateEntity(request, summary);
+        return consultationSummaryMapper.toResponse(consultationSummaryRepository.save(summary));
+    }
+
+    @Override
+    @Transactional
+    public void delete(UUID id) {
+        User user = authService.getAuthenticateUser();
+        UUID userId = user.getId();
+        ConsultationSummary summary = consultationSummaryRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Consultation summary not found"));
+        boolean doctor = summary.getDoctor().getId().equals(userId);
+        boolean patient = summary.getPatient().getId().equals(userId);
+        if (!doctor && !patient) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Only the patient or authoring doctor can delete this summary");
+        }
+        summary.delete(String.valueOf(userId));
+        consultationSummaryRepository.save(summary);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ConsultationSummaryResponse> list(UUID patientIdParam,
+            Specialization specialization, Pageable pageable) {
+        User user = authService.getAuthenticateUser();
+        boolean patientRole = hasAuthority(user, "ROLE_PATIENT");
+        boolean doctorRole = hasAuthority(user, "ROLE_DOCTOR");
+
+        if (patientIdParam != null && patientRole) {
+            throw new IllegalArgumentException("patientId must not be sent by patients");
+        }
+        if (doctorRole && patientIdParam == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Doctors must provide patientId to list consultation summaries");
+        }
+        ConsultationSummaryFilter listFilter = new ConsultationSummaryFilter(specialization);
+        if (patientRole) {
+            Specification<ConsultationSummary> spec = ConsultationSummarySpecification
+                    .filter(listFilter, user.getId());
+            return consultationSummaryRepository.findAll(spec, pageable)
+                    .map(consultationSummaryMapper::toResponse);
+        }
+        if (doctorRole) {
+            boolean gateOk = consultationRepository.existsByDoctorAndPatientAndStatusNotIn(
+                    user.getId(), patientIdParam, LIST_GATE_EXCLUDED_STATUSES);
+            if (!gateOk) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                        "No qualifying consultation with this patient");
+            }
+            Specification<ConsultationSummary> spec = ConsultationSummarySpecification
+                    .filter(listFilter, patientIdParam);
+            return consultationSummaryRepository.findAll(spec, pageable)
+                    .map(consultationSummaryMapper::toResponse);
+        }
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Unsupported role");
+    }
+
+    private void assertParticipantOrThrow(ConsultationSummary summary) {
+        UUID userId = authService.getAuthenticateUserId();
+        if (!summary.getPatient().getId().equals(userId)
+                && !summary.getDoctor().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You cannot access this consultation summary");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V13__Create_consultation_summary.sql
+++ b/src/main/resources/db/migration/V13__Create_consultation_summary.sql
@@ -1,0 +1,21 @@
+CREATE TABLE consultation_summary (
+    id                 UUID PRIMARY KEY         DEFAULT gen_random_uuid(),
+    summary            TEXT,
+    recovery_plan      TEXT,
+    medicine_summary   JSONB,
+    required_lab_test  JSONB,
+    doctor_id          UUID        NOT NULL     REFERENCES doctor (id),
+    patient_id         UUID        NOT NULL     REFERENCES patient (id),
+    consultation_id    UUID        NOT NULL     REFERENCES consultation (id),
+    created_at         TIMESTAMPTZ NOT NULL,
+    updated_at         TIMESTAMPTZ,
+    created_by         UUID        NOT NULL,
+    updated_by         UUID,
+    deleted            BOOLEAN     NOT NULL DEFAULT FALSE,
+    deleted_by         VARCHAR(255),
+    deleted_at         TIMESTAMPTZ,
+    CONSTRAINT uq_consultation_summary_consultation UNIQUE (consultation_id)
+);
+
+CREATE INDEX idx_consultation_summary_patient ON consultation_summary (patient_id);
+CREATE INDEX idx_consultation_summary_doctor ON consultation_summary (doctor_id);

--- a/src/test/java/com/nexaworks/rafiq/integration/controller/ConsultationSummaryControllerIntegrationTest.java
+++ b/src/test/java/com/nexaworks/rafiq/integration/controller/ConsultationSummaryControllerIntegrationTest.java
@@ -1,0 +1,257 @@
+package com.nexaworks.rafiq.integration.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexaworks.rafiq.dto.request.summary.CreateConsultationSummaryRequest;
+import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
+import com.nexaworks.rafiq.entities.Consultation;
+import com.nexaworks.rafiq.entities.Doctor;
+import com.nexaworks.rafiq.entities.Patient;
+import com.nexaworks.rafiq.entities.Role;
+import com.nexaworks.rafiq.entities.TimeSlot;
+import com.nexaworks.rafiq.entities.enums.ConsultationStatus;
+import com.nexaworks.rafiq.entities.enums.Specialization;
+import com.nexaworks.rafiq.integration.BaseIntegrationTest;
+import com.nexaworks.rafiq.repository.CancellationLogRepository;
+import com.nexaworks.rafiq.repository.ConsultationRepository;
+import com.nexaworks.rafiq.repository.ConsultationSummaryRepository;
+import com.nexaworks.rafiq.repository.DoctorRepository;
+import com.nexaworks.rafiq.repository.PatientRepository;
+import com.nexaworks.rafiq.repository.RoleRepository;
+import com.nexaworks.rafiq.repository.UserRepository;
+
+@DisplayName("Consultation summary API integration tests")
+public class ConsultationSummaryControllerIntegrationTest extends BaseIntegrationTest {
+
+    private static final String BASE = "/consultation-summary";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private DoctorRepository doctorRepository;
+    @Autowired
+    private PatientRepository patientRepository;
+    @Autowired
+    private ConsultationRepository consultationRepository;
+    @Autowired
+    private ConsultationSummaryRepository consultationSummaryRepository;
+    @Autowired
+    private CancellationLogRepository cancellationLogRepository;
+    @Autowired
+    private RoleRepository roleRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void cleanDatabase() {
+        consultationSummaryRepository.deleteAll();
+        cancellationLogRepository.deleteAll();
+        consultationRepository.deleteAll();
+        patientRepository.deleteAll();
+        doctorRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private Doctor createDoctor() {
+        Role doctorRole = roleRepository.findByName("ROLE_DOCTOR");
+        Doctor doctor = Doctor.builder().email("d@example.com")
+                .password(passwordEncoder.encode("Valid@1234")).firstName("Jane").lastName("Doe")
+                .specialization(Specialization.CARDIOLOGY).price(BigDecimal.valueOf(150))
+                .roles(Set.of(doctorRole)).enabled(true).build();
+        return doctorRepository.save(doctor);
+    }
+
+    private Patient createPatient() {
+        Role patientRole = roleRepository.findByName("ROLE_PATIENT");
+        Patient patient = Patient.builder().email("p@example.com")
+                .password(passwordEncoder.encode("Valid@1234")).firstName("John").lastName("Smith")
+                .roles(Set.of(patientRole)).enabled(true).build();
+        return patientRepository.save(patient);
+    }
+
+    private Consultation persistConsultation(Doctor doctor, Patient patient,
+            ConsultationStatus status) {
+        return persistConsultation(doctor, patient, status,
+                LocalDateTime.now().plusDays(1).withNano(0));
+    }
+
+    private Consultation persistConsultation(Doctor doctor, Patient patient,
+            ConsultationStatus status, LocalDateTime start) {
+        TimeSlot slot = TimeSlot.builder().startTime(start).endTime(start.plusMinutes(60))
+                .durationMinutes(60).build();
+        Consultation c = Consultation.builder().doctor(doctor).patient(patient).timeSlot(slot)
+                .status(status).specialization(doctor.getSpecialization()).build();
+        return consultationRepository.save(c);
+    }
+
+    private CreateConsultationSummaryRequest createRequest(UUID consultationId) {
+        return new CreateConsultationSummaryRequest(consultationId, "Visit summary", "Rest well",
+                List.of(), List.of("CBC"));
+    }
+
+    @Nested
+    class CreateSummary {
+        @Test
+        void doctorCreatesSummary_whenCompleted() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.COMPLETED);
+
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk())
+                    .andExpect(jsonPath("$.summary").value("Visit summary"))
+                    .andExpect(jsonPath("$.consultationId").value(c.getId().toString()));
+
+            assertThat(consultationSummaryRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        void doctorRejected_whenConsultationNotCompleted() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.CONFIRMED);
+
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class GetAndList {
+        @Test
+        void patientAndDoctorCanGet_whenParticipant() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.COMPLETED);
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+
+            UUID summaryId = consultationSummaryRepository.findAll().get(0).getId();
+
+            mockMvc.perform(get(BASE + "/" + summaryId).with(withUserId(patient)))
+                    .andExpect(status().isOk()).andExpect(jsonPath("$.id").exists());
+
+            mockMvc.perform(get(BASE + "/" + summaryId).with(withUserId(doctor)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void patientListsOwnSummaries() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.COMPLETED);
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+
+            mockMvc.perform(
+                    get(BASE).param("page", "0").param("size", "10").with(withUserId(patient)))
+                    .andExpect(status().isOk()).andExpect(jsonPath("$.content.length()").value(1));
+        }
+
+        @Test
+        void doctorForbidden_listWithoutPatientId() throws Exception {
+            Doctor doctor = createDoctor();
+            mockMvc.perform(
+                    get(BASE).param("page", "0").param("size", "10").with(withUserId(doctor)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void doctorListsPatientSummaries_whenGateConsultationActive() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation completed = persistConsultation(doctor, patient,
+                    ConsultationStatus.COMPLETED, LocalDateTime.now().plusDays(1).withNano(0));
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(completed.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+            persistConsultation(doctor, patient, ConsultationStatus.CONFIRMED,
+                    LocalDateTime.now().plusDays(2).withNano(0));
+
+            mockMvc.perform(get(BASE).param("page", "0").param("size", "10")
+                    .param("patientId", patient.getId().toString()).with(withUserId(doctor)))
+                    .andExpect(status().isOk()).andExpect(jsonPath("$.content.length()").value(1));
+        }
+
+        @Test
+        void doctorForbidden_listWhenOnlyTerminalConsultations() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation completed = persistConsultation(doctor, patient,
+                    ConsultationStatus.COMPLETED, LocalDateTime.now().plusDays(1).withNano(0));
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(completed.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+            persistConsultation(doctor, patient, ConsultationStatus.COMPLETED,
+                    LocalDateTime.now().plusDays(2).withNano(0));
+
+            mockMvc.perform(get(BASE).param("page", "0").param("size", "10")
+                    .param("patientId", patient.getId().toString()).with(withUserId(doctor)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    class UpdateDelete {
+        @Test
+        void doctorUpdates() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.COMPLETED);
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+            UUID summaryId = consultationSummaryRepository.findAll().get(0).getId();
+            UpdateConsultationSummaryRequest upd = new UpdateConsultationSummaryRequest("Updated",
+                    null, null, null);
+
+            mockMvc.perform(put(BASE + "/" + summaryId).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(upd)).with(withUserId(doctor)))
+                    .andExpect(status().isOk()).andExpect(jsonPath("$.summary").value("Updated"));
+        }
+
+        @Test
+        void patientDeletes() throws Exception {
+            Doctor doctor = createDoctor();
+            Patient patient = createPatient();
+            Consultation c = persistConsultation(doctor, patient, ConsultationStatus.COMPLETED);
+            mockMvc.perform(post(BASE).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest(c.getId())))
+                    .with(withUserId(doctor))).andExpect(status().isOk());
+            UUID summaryId = consultationSummaryRepository.findAll().get(0).getId();
+
+            mockMvc.perform(delete(BASE + "/" + summaryId).with(withUserId(patient)))
+                    .andExpect(status().isNoContent());
+        }
+    }
+}

--- a/src/test/java/com/nexaworks/rafiq/unit/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/nexaworks/rafiq/unit/service/ReservationServiceImplTest.java
@@ -76,7 +76,7 @@ class ReservationServiceImplTest {
 
     @Test
     @DisplayName("should reserve consultation successfully and return client secret")
-    void shouldReserveSuccessfullyAndReturnClientSecret() {
+    void shouldReserveSuccessfullyAndReturnClientSecret() throws Exception {
         Consultation consultation = Consultation.builder().id(consultationId)
                 .status(ConsultationStatus.AVAILABLE).timeSlot(timeSlot).build();
 
@@ -107,7 +107,7 @@ class ReservationServiceImplTest {
 
     @Test
     @DisplayName("should throw when consultation status is not AVAILABLE")
-    void shouldThrowWhenConsultationStatusIsNotAvailable() {
+    void shouldThrowWhenConsultationStatusIsNotAvailable() throws Exception {
         Consultation consultation = Consultation.builder().id(consultationId)
                 .status(ConsultationStatus.BOOKED).timeSlot(timeSlot).build();
 
@@ -127,7 +127,7 @@ class ReservationServiceImplTest {
 
     @Test
     @DisplayName("should throw when patient has overlapping consultation")
-    void shouldThrowWhenPatientHasOverlappingConsultation() {
+    void shouldThrowWhenPatientHasOverlappingConsultation() throws Exception {
         Consultation consultation = Consultation.builder().id(consultationId)
                 .status(ConsultationStatus.AVAILABLE).timeSlot(timeSlot).build();
 
@@ -147,7 +147,7 @@ class ReservationServiceImplTest {
 
     @Test
     @DisplayName("should not update consultation status if payment service fails")
-    void shouldNotPersistConsultationWhenPaymentFails() {
+    void shouldNotPersistConsultationWhenPaymentFails() throws Exception {
         Consultation consultation = Consultation.builder().id(consultationId)
                 .status(ConsultationStatus.AVAILABLE).timeSlot(timeSlot).build();
 

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -76,3 +76,6 @@ CLOUDINARY_API_SECRET: test-cloudinary-secret
 # Agora placeholders (RtcProvider is mocked in IntegrationTestExternalMocks; SDK is not used).
 AGORA_APP_ID: "00000000000000000000000000000000"
 AGORA_APP_CERTIFICATE: "00000000000000000000000000000000"
+
+# Stripe (StripeConfig)
+STRIPE_API_SECRET: sk_test_integration_placeholder


### PR DESCRIPTION
This pull request introduces a new feature for managing consultation summaries in the application. It adds the necessary entities, DTOs, controller, service, repository, and mapping logic to support creating, updating, retrieving, deleting, and listing consultation summaries. Additionally, it refactors related entities and improves the mapping and repository layers to accommodate this new feature.

**Consultation Summary Feature Implementation:**

* Added the `ConsultationSummary` entity, which includes fields for summary, recovery plan, medicine summary, required lab tests, and associations with doctor, patient, and consultation. (`src/main/java/com/nexaworks/rafiq/entities/ConsultationSummary.java`)
* Created DTOs for requests and responses related to consultation summaries: `CreateConsultationSummaryRequest`, `UpdateConsultationSummaryRequest`, `ConsultationSummaryResponse`, and `ConsultationSummaryFilter`. (`src/main/java/com/nexaworks/rafiq/dto/request/summary/`, `src/main/java/com/nexaworks/rafiq/dto/response/summary/`) [[1]](diffhunk://#diff-8e21e6373e9aa314a7754e9b9bf918d7636873697de27d3b84e43aff87afcff9R1-R12) [[2]](diffhunk://#diff-4ffe340493ae45b519554816df17d3fc08d039afe60fae4f37c4f70bb68ca416R1-R9) [[3]](diffhunk://#diff-ec267ffe590eced3958181d01df17a2442c4aa10a75bf6b1030bc0a9890c2d2bR1-R11) [[4]](diffhunk://#diff-eadd13ca2fde1802257ae37e6f6f63a2f3e985c53d1efc941039b2dc7fcbe21aR1-R6)
* Implemented the `ConsultationSummaryController` to handle REST API endpoints for CRUD operations and listing of consultation summaries, with appropriate authorization. (`src/main/java/com/nexaworks/rafiq/controller/ConsultationSummaryController.java`)
* Added the `ConsultationSummaryService` interface for business logic and the `ConsultationSummaryRepository` for database access, including a specification for filtering summaries. (`src/main/java/com/nexaworks/rafiq/service/summary/ConsultationSummaryService.java`, `src/main/java/com/nexaworks/rafiq/repository/ConsultationSummaryRepository.java`, `src/main/java/com/nexaworks/rafiq/repository/specification/ConsultationSummarySpecification.java`) [[1]](diffhunk://#diff-9515489323123de1a5887cd15e0ce2298c6028621afee7dabd6c4a2cb3b9eaf2R1-R25) [[2]](diffhunk://#diff-a612e40b8a650c4586a376b830332b3121fac05ad2534b1590dc731f64fff5d6R1-R17) [[3]](diffhunk://#diff-87838453fd7f2e70e7345a7c758813e643437a807b0b23bd66850773c68711a8R1-R29)
* Introduced the `ConsultationSummaryMapper` for mapping between entities and DTOs. (`src/main/java/com/nexaworks/rafiq/mapper/ConsultationSummaryMapper.java`)

**Related Entity and Mapper Adjustments:**

* Updated the `Consultation` entity to include a one-to-one relationship with `ConsultationSummary`. (`src/main/java/com/nexaworks/rafiq/entities/Consultation.java`)
* Added the `MedicineSummary` class for use in consultation summaries. (`src/main/java/com/nexaworks/rafiq/entities/MedicineSummary.java`)
* Updated `ConsultationMapper` to correctly map the summary ID in patient consultation responses. (`src/main/java/com/nexaworks/rafiq/mapper/ConsultationMapper.java`)

**Repository and Specification Enhancements:**

* Added a repository method to check for the existence of consultations between a doctor and patient, excluding certain statuses. (`src/main/java/com/nexaworks/rafiq/repository/ConsultationRepository.java`)
* Introduced filtering logic for consultation summaries by specialization and patient. (`src/main/java/com/nexaworks/rafiq/repository/specification/ConsultationSummarySpecification.java`)

**Minor Refactoring:**

* Removed the `doctor` field from the `Medicine` entity and its related index, as it is no longer needed. (`src/main/java/com/nexaworks/rafiq/entities/Medicine.java`) [[1]](diffhunk://#diff-ba36bfaaf4f26a68e2c4498939e64f6f81e2c223fd3978fc3a97c2b063a8fe89L21-R21) [[2]](diffhunk://#diff-ba36bfaaf4f26a68e2c4498939e64f6f81e2c223fd3978fc3a97c2b063a8fe89L66-L69)
* Minor dependency injection adjustment in `PaymentTrackingService` to use `@Lazy` for `PaymentScheduler`. (`src/main/java/com/nexaworks/rafiq/service/payment/PaymentTrackingService.java`) [[1]](diffhunk://#diff-f4e7a375b1267cd4264219a04174205c96e343ded90c647cad897b20e9687dffR6) [[2]](diffhunk://#diff-f4e7a375b1267cd4264219a04174205c96e343ded90c647cad897b20e9687dffL20-R36)