### PR TITLE
Fix/idempotency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     environment: development
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
       - name: Checkout code
@@ -32,6 +33,11 @@ jobs:
 
       - name: Make mvnw executable
         run: chmod +x ./mvnw
+
+      - name: Pre-pull Testcontainers images
+        run: |
+          docker pull postgres:15
+          docker pull rabbitmq:3-management
 
       - name: Run Tests
         run: ./mvnw clean verify -B

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.melbiialy</groupId>
-            <artifactId>idempotency-spring-boot-starter</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/src/main/java/com/nexaworks/rafiq/RafiqApplication.java
+++ b/src/main/java/com/nexaworks/rafiq/RafiqApplication.java
@@ -2,12 +2,15 @@ package com.nexaworks.rafiq;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import com.nexaworks.rafiq.idempotency.configuration.IdempotencyProperties;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "applicationAuditAware")
@@ -16,6 +19,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableFeignClients
 @EnableScheduling
 @EnableCaching
+@EnableConfigurationProperties(IdempotencyProperties.class)
+
 public class RafiqApplication {
     public static void main(String[] args) {
         SpringApplication.run(RafiqApplication.class, args);

--- a/src/main/java/com/nexaworks/rafiq/config/FirebaseConfig.java
+++ b/src/main/java/com/nexaworks/rafiq/config/FirebaseConfig.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -13,6 +14,7 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 
 @Configuration
+@Profile("!test")
 public class FirebaseConfig {
     @Value("${app.firebase.config-file}")
     private String firebaseConfigFile;

--- a/src/main/java/com/nexaworks/rafiq/config/RedisConfig.java
+++ b/src/main/java/com/nexaworks/rafiq/config/RedisConfig.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -35,6 +38,7 @@ public class RedisConfig {
     }
 
     @Bean
+    @ConditionalOnBean(RedisConnectionFactory.class)
     public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
@@ -55,6 +59,8 @@ public class RedisConfig {
     }
 
     @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean(RedissonClient.class)
+    @ConditionalOnProperty(prefix = "app.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
     public RedissonClient redissonClient() throws IOException {
         Config config = Config
                 .fromYAML(new ClassPathResource("redisson-dev.yaml").getInputStream());
@@ -62,6 +68,7 @@ public class RedisConfig {
     }
 
     @Bean
+    @ConditionalOnBean(RedisConnectionFactory.class)
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
         return new StringRedisTemplate(cf);
     }

--- a/src/main/java/com/nexaworks/rafiq/controller/ConsultationCallController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ConsultationCallController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nexaworks.rafiq.dto.response.consultation.CallResponse;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.consultation.ConsultationCallService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/nexaworks/rafiq/controller/ConsultationController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ConsultationController.java
@@ -16,11 +16,11 @@ import com.nexaworks.rafiq.dto.response.consultation.ConsultationResponse;
 import com.nexaworks.rafiq.dto.response.consultation.PatientConsultationResponse;
 import com.nexaworks.rafiq.dto.response.consultation.ReserveConsultationResponse;
 import com.nexaworks.rafiq.entities.enums.ConsultationStatus;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.consultation.IConsultationCancellationService;
 import com.nexaworks.rafiq.service.consultation.IConsultationSearchService;
 import com.nexaworks.rafiq.service.consultation.IReservationService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/nexaworks/rafiq/controller/ConsultationSlotController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ConsultationSlotController.java
@@ -17,11 +17,11 @@ import com.nexaworks.rafiq.dto.response.consultation.ConsultationSlotResponse;
 import com.nexaworks.rafiq.dto.response.consultation.DoctorConsultationResponse;
 import com.nexaworks.rafiq.dto.response.consultation.EditConsultationSlotResponse;
 import com.nexaworks.rafiq.dto.response.consultation.ScheduleResponse;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.consultation.IConsultationSearchService;
 import com.nexaworks.rafiq.service.consultation.IConsultationSlotHoldingService;
 import com.nexaworks.rafiq.service.consultation.IConsultationSlotService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/nexaworks/rafiq/controller/ConsultationSummaryController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ConsultationSummaryController.java
@@ -13,9 +13,9 @@ import com.nexaworks.rafiq.dto.request.summary.UpdateConsultationSummaryRequest;
 import com.nexaworks.rafiq.dto.response.common.PageResponse;
 import com.nexaworks.rafiq.dto.response.summary.ConsultationSummaryResponse;
 import com.nexaworks.rafiq.entities.enums.Specialization;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.summary.ConsultationSummaryService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/nexaworks/rafiq/controller/GroupController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/GroupController.java
@@ -17,10 +17,10 @@ import com.nexaworks.rafiq.dto.response.Group.GroupDetailsResponse;
 import com.nexaworks.rafiq.dto.response.common.PageResponse;
 import com.nexaworks.rafiq.dto.response.common.Response;
 import com.nexaworks.rafiq.dto.response.medicine.AddResponse;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.medicine.GroupService;
 import com.nexaworks.rafiq.service.medicine.IMedicineService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/nexaworks/rafiq/controller/MedicineController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/MedicineController.java
@@ -16,9 +16,9 @@ import com.nexaworks.rafiq.dto.response.medicine.AddResponse;
 import com.nexaworks.rafiq.dto.response.medicine.BulkOperationResponse;
 import com.nexaworks.rafiq.dto.response.medicine.MedicineGroupResponse;
 import com.nexaworks.rafiq.dto.response.medicine.MedicineResponse;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.medicine.IMedicineService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;

--- a/src/main/java/com/nexaworks/rafiq/controller/ReminderController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/ReminderController.java
@@ -19,9 +19,9 @@ import com.nexaworks.rafiq.dto.response.reminder.AddReminderResponse;
 import com.nexaworks.rafiq.dto.response.reminder.GetAllRemindersResponse;
 import com.nexaworks.rafiq.dto.response.reminder.GetReminderByIdResponse;
 import com.nexaworks.rafiq.entities.enums.ReminderStatus;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.medicine.ReminderService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/nexaworks/rafiq/controller/UserController.java
+++ b/src/main/java/com/nexaworks/rafiq/controller/UserController.java
@@ -13,10 +13,10 @@ import com.nexaworks.rafiq.dto.request.user.ForgetPasswordRequest;
 import com.nexaworks.rafiq.dto.request.user.UserRegistrationRequest;
 import com.nexaworks.rafiq.dto.request.user.VerificationRequest;
 import com.nexaworks.rafiq.dto.response.auth.LoginResponse;
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
 import com.nexaworks.rafiq.service.user.TokenService;
 import com.nexaworks.rafiq.service.user.UserService;
 
-import dev.once.annotation.Idempotent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/nexaworks/rafiq/idempotency/annotation/Idempotent.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/annotation/Idempotent.java
@@ -1,0 +1,13 @@
+package com.nexaworks.rafiq.idempotency.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+    String header() default "Idempotency-Key";
+    boolean force() default false;
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyConfiguration.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyConfiguration.java
@@ -1,10 +1,8 @@
 package com.nexaworks.rafiq.idempotency.configuration;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,7 +15,6 @@ import com.nexaworks.rafiq.idempotency.storage.InMemoryIdempotencyStore;
 @Import(RedisIdempotencyConfiguration.class)
 public class IdempotencyConfiguration {
     @Bean
-    @ConditionalOnMissingBean({IdempotencyStore.class, RedisConnectionFactory.class})
     public IdempotencyStore inMemoryIdempotencyStore(IdempotencyProperties properties) {
         return new InMemoryIdempotencyStore(properties.getTtl().getSeconds());
     }

--- a/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyConfiguration.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyConfiguration.java
@@ -1,0 +1,43 @@
+package com.nexaworks.rafiq.idempotency.configuration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.nexaworks.rafiq.idempotency.filter.IdempotencyFilter;
+import com.nexaworks.rafiq.idempotency.filter.WrapperFilter;
+import com.nexaworks.rafiq.idempotency.storage.IdempotencyStore;
+import com.nexaworks.rafiq.idempotency.storage.InMemoryIdempotencyStore;
+
+@Configuration
+@Import(RedisIdempotencyConfiguration.class)
+public class IdempotencyConfiguration {
+    @Bean
+    @ConditionalOnMissingBean({IdempotencyStore.class, RedisConnectionFactory.class})
+    public IdempotencyStore inMemoryIdempotencyStore(IdempotencyProperties properties) {
+        return new InMemoryIdempotencyStore(properties.getTtl().getSeconds());
+    }
+
+    @Bean
+    public IdempotencyFilter idempotencyFilter(IdempotencyStore idempotencyStore) {
+        return new IdempotencyFilter(idempotencyStore);
+    }
+    @Bean
+    public WrapperFilter wrapperFilter(IdempotencyStore idempotencyStore) {
+        return new WrapperFilter(idempotencyStore);
+    }
+    @Bean
+    public WebMvcConfigurer idempotencyWebMvcConfigurer(IdempotencyFilter idempotencyFilter) {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addInterceptors(InterceptorRegistry registry) {
+                registry.addInterceptor(idempotencyFilter);
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyProperties.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyProperties.java
@@ -3,6 +3,11 @@ package com.nexaworks.rafiq.idempotency.configuration;
 import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+@Setter
+@Getter
 @ConfigurationProperties(prefix = "idempotency")
 public class IdempotencyProperties {
     private String headerName = "Idempotency-Key";
@@ -11,27 +16,4 @@ public class IdempotencyProperties {
 
     private boolean enabled = true;
 
-    public String getHeaderName() {
-        return headerName;
-    }
-
-    public void setHeaderName(String headerName) {
-        this.headerName = headerName;
-    }
-
-    public Duration getTtl() {
-        return ttl;
-    }
-
-    public void setTtl(Duration ttl) {
-        this.ttl = ttl;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
 }

--- a/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyProperties.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/configuration/IdempotencyProperties.java
@@ -1,0 +1,37 @@
+package com.nexaworks.rafiq.idempotency.configuration;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+@ConfigurationProperties(prefix = "idempotency")
+public class IdempotencyProperties {
+    private String headerName = "Idempotency-Key";
+
+    private Duration ttl = Duration.ofHours(10);
+
+    private boolean enabled = true;
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public void setHeaderName(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public Duration getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Duration ttl) {
+        this.ttl = ttl;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/configuration/RedisIdempotencyConfiguration.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/configuration/RedisIdempotencyConfiguration.java
@@ -1,0 +1,41 @@
+package com.nexaworks.rafiq.idempotency.configuration;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexaworks.rafiq.idempotency.storage.IdempotencyStore;
+import com.nexaworks.rafiq.idempotency.storage.RedisIdempotencyStore;
+
+@Configuration
+@ConditionalOnClass(RedisConnectionFactory.class)
+@ConditionalOnBean(RedisConnectionFactory.class)
+public class RedisIdempotencyConfiguration {
+
+    @Bean("idempotencyRedisTemplate")
+    @ConditionalOnProperty(prefix = "idempotency", name = "store-type", havingValue = "redis")
+    public RedisTemplate<String, String> idempotencyRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(IdempotencyStore.class)
+    public IdempotencyStore redisIdempotencyStore(
+            @Qualifier("idempotencyRedisTemplate") RedisTemplate<String, String> template,
+            ObjectMapper objectMapper, IdempotencyProperties properties) {
+        return new RedisIdempotencyStore(template, objectMapper, properties.getTtl().toSeconds());
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/exceptions/RequestInFlightException.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/exceptions/RequestInFlightException.java
@@ -1,0 +1,7 @@
+package com.nexaworks.rafiq.idempotency.exceptions;
+
+public class RequestInFlightException extends RuntimeException {
+    public RequestInFlightException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/filter/IdempotencyFilter.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/filter/IdempotencyFilter.java
@@ -1,0 +1,67 @@
+package com.nexaworks.rafiq.idempotency.filter;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.nexaworks.rafiq.idempotency.annotation.Idempotent;
+import com.nexaworks.rafiq.idempotency.exceptions.RequestInFlightException;
+import com.nexaworks.rafiq.idempotency.storage.IdempotencyStore;
+import com.nexaworks.rafiq.idempotency.storage.IdempotentResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class IdempotencyFilter implements HandlerInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyFilter.class);
+    private final IdempotencyStore idempotencyStore;
+
+    public IdempotencyFilter(IdempotencyStore idempotencyStore) {
+        this.idempotencyStore = idempotencyStore;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+            Object handler) throws IOException {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+        Idempotent annotation = ((HandlerMethod) handler).getMethodAnnotation(Idempotent.class);
+        if (annotation == null) {
+            return true;
+        }
+
+        String header = annotation.header();
+        String key = request.getHeader(header);
+        if (key == null && !annotation.force()) {
+            return true;
+        } else if (key == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"missing_idempotency_key\"}");
+            return false;
+        }
+        String generatedKey = request.getMethod() + ":" + request.getRequestURI() + ":" + key;
+        IdempotentResponse cached = idempotencyStore.get(generatedKey);
+
+        if (cached != null) {
+            if (cached.isInFlight()) {
+                throw new RequestInFlightException("Request is in flight");
+            }
+            response.setStatus(cached.statusCode());
+            response.setContentType(cached.contentType());
+            cached.headers().forEach(response::setHeader);
+            response.getOutputStream().write(cached.body());
+            response.getOutputStream().flush();
+            return false;
+        }
+
+        idempotencyStore.setInFlight(generatedKey);
+        request.setAttribute("idempotency_key", generatedKey);
+        return true;
+    }
+
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/filter/WrapperFilter.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/filter/WrapperFilter.java
@@ -34,7 +34,6 @@ public class WrapperFilter extends OncePerRequestFilter {
         } finally {
             String key = (String) request.getAttribute("idempotency_key");
             if (key != null) {
-                logger.info("idempotency key: " + key + "g");
                 byte[] body = responseWrapper.getContent();
                 Map<String, String> headers = new HashMap<>();
                 responseWrapper.getHeaderNames()

--- a/src/main/java/com/nexaworks/rafiq/idempotency/filter/WrapperFilter.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/filter/WrapperFilter.java
@@ -1,0 +1,48 @@
+package com.nexaworks.rafiq.idempotency.filter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.nexaworks.rafiq.idempotency.storage.IdempotencyStore;
+import com.nexaworks.rafiq.idempotency.storage.IdempotentResponse;
+import com.nexaworks.rafiq.idempotency.storage.Status;
+import com.nexaworks.rafiq.idempotency.wrapper.ContentCachingResponseWrapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class WrapperFilter extends OncePerRequestFilter {
+    private final IdempotencyStore idempotencyStore;
+
+    public WrapperFilter(IdempotencyStore idempotencyStore) {
+        this.idempotencyStore = idempotencyStore;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+        try {
+            filterChain.doFilter(request, responseWrapper);
+        } finally {
+            String key = (String) request.getAttribute("idempotency_key");
+            if (key != null) {
+                logger.info("idempotency key: " + key + "g");
+                byte[] body = responseWrapper.getContent();
+                Map<String, String> headers = new HashMap<>();
+                responseWrapper.getHeaderNames()
+                        .forEach(name -> headers.put(name, responseWrapper.getHeader(name)));
+                idempotencyStore.set(key, new IdempotentResponse(response.getStatus(), body,
+                        response.getContentType(), Instant.now(), headers, Status.COMPLETED));
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/storage/IdempotencyStore.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/storage/IdempotencyStore.java
@@ -1,0 +1,10 @@
+package com.nexaworks.rafiq.idempotency.storage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface IdempotencyStore {
+    void set(String key, IdempotentResponse idempotentResponse) throws JsonProcessingException;
+    IdempotentResponse get(String key);
+    void delete(String key);
+    void setInFlight(String key);
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/storage/IdempotentResponse.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/storage/IdempotentResponse.java
@@ -1,0 +1,18 @@
+package com.nexaworks.rafiq.idempotency.storage;
+
+import java.time.Instant;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record IdempotentResponse(int statusCode, byte[] body, String contentType, Instant timestamp,
+        Map<String, String> headers, Status status) {
+    public static IdempotentResponse inFlight() {
+        return new IdempotentResponse(0, null, null, Instant.now(), Map.of(), Status.IN_FLIGHT);
+    }
+
+    @JsonIgnore
+    public boolean isInFlight() {
+        return status == Status.IN_FLIGHT;
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/storage/InMemoryIdempotencyStore.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/storage/InMemoryIdempotencyStore.java
@@ -1,0 +1,45 @@
+package com.nexaworks.rafiq.idempotency.storage;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+
+    private final Map<String, IdempotentResponse> store = new ConcurrentHashMap<>();
+    private final long ttlSeconds;
+
+    public InMemoryIdempotencyStore(long ttlSeconds) {
+        this.ttlSeconds = ttlSeconds;
+    }
+
+    @Override
+    public void set(String key, IdempotentResponse response) {
+        store.put(key, response);
+    }
+
+    @Override
+    public void setInFlight(String key) {
+        store.put(key, IdempotentResponse.inFlight());
+    }
+
+    @Override
+    public IdempotentResponse get(String key) {
+        IdempotentResponse response = store.get(key);
+        if (response == null)
+            return null;
+
+        if (!response.isInFlight()
+                && response.timestamp().plusSeconds(ttlSeconds).isBefore(Instant.now())) {
+            store.remove(key);
+            return null;
+        }
+
+        return response;
+    }
+
+    @Override
+    public void delete(String key) {
+        store.remove(key);
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/storage/RedisIdempotencyStore.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/storage/RedisIdempotencyStore.java
@@ -1,0 +1,68 @@
+package com.nexaworks.rafiq.idempotency.storage;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RedisIdempotencyStore implements IdempotencyStore {
+    private final RedisTemplate<String, String> template;
+    private final long ttlSeconds;
+    private final ObjectMapper objectMapper;
+
+    public RedisIdempotencyStore(RedisTemplate<String, String> template, ObjectMapper objectMapper,
+            long ttlSeconds) {
+        this.template = template;
+        this.ttlSeconds = ttlSeconds;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void set(String key, IdempotentResponse idempotentResponse) {
+        try {
+            String json = objectMapper.writeValueAsString(idempotentResponse);
+            template.opsForValue().set(key, json, ttlSeconds, TimeUnit.SECONDS);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize idempotent response:", e);
+        }
+
+    }
+
+    @Override
+    public IdempotentResponse get(String key) {
+        String json = template.opsForValue().get(key);
+        if (json == null) {
+            return null;
+        }
+        try {
+            IdempotentResponse response = objectMapper.readValue(json, IdempotentResponse.class);
+            if (!response.isInFlight()
+                    && response.timestamp().plusSeconds(ttlSeconds).isBefore(Instant.now())) {
+                template.delete(key);
+                return null;
+            }
+            return response;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to deserialize idempotent response", e);
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        template.delete(key);
+    }
+
+    @Override
+    public void setInFlight(String key) {
+        try {
+            String json = objectMapper.writeValueAsString(IdempotentResponse.inFlight());
+            template.opsForValue().set(key, json, 30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set in-flight state", e);
+        }
+
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/storage/Status.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/storage/Status.java
@@ -1,0 +1,5 @@
+package com.nexaworks.rafiq.idempotency.storage;
+
+public enum Status {
+    IN_FLIGHT, COMPLETED
+}

--- a/src/main/java/com/nexaworks/rafiq/idempotency/wrapper/ContentCachingResponseWrapper.java
+++ b/src/main/java/com/nexaworks/rafiq/idempotency/wrapper/ContentCachingResponseWrapper.java
@@ -1,0 +1,46 @@
+package com.nexaworks.rafiq.idempotency.wrapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+public class ContentCachingResponseWrapper extends HttpServletResponseWrapper {
+
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private ServletOutputStream servletOutputStream;
+
+    public ContentCachingResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+    @Override
+    public ServletOutputStream getOutputStream() {
+        if (servletOutputStream == null) {
+            servletOutputStream = new ServletOutputStream() {
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setWriteListener(WriteListener listener) {
+
+                }
+
+                @Override
+                public void write(int b) throws IOException {
+                    outputStream.write(b);
+                    getResponse().getOutputStream().write(b);
+                    getResponse().getOutputStream().flush();
+                }
+            };
+        }
+        return servletOutputStream;
+    }
+    public byte[] getContent() {
+        return outputStream.toByteArray();
+    }
+}

--- a/src/main/java/com/nexaworks/rafiq/mapper/FeedbackMapper.java
+++ b/src/main/java/com/nexaworks/rafiq/mapper/FeedbackMapper.java
@@ -1,0 +1,40 @@
+package com.nexaworks.rafiq.mapper;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.nexaworks.rafiq.dto.response.feedback.FeedbackResponse;
+import com.nexaworks.rafiq.entities.Feedback;
+import com.nexaworks.rafiq.entities.Patient;
+
+@Mapper(componentModel = "spring")
+public interface FeedbackMapper {
+
+    @Mapping(target = "comment", source = "feedback")
+    @Mapping(target = "patientName", expression = "java(buildPatientName(feedback.getPatient()))")
+    @Mapping(target = "createdAt", expression = "java(toLocalDate(feedback.getCreatedAt()))")
+    FeedbackResponse toResponse(Feedback feedback);
+
+    List<FeedbackResponse> toResponseList(List<Feedback> feedbacks);
+
+    default String buildPatientName(Patient patient) {
+        if (patient == null) {
+            return "";
+        }
+        String firstName = patient.getFirstName() == null ? "" : patient.getFirstName().trim();
+        String lastName = patient.getLastName() == null ? "" : patient.getLastName().trim();
+        return (firstName + " " + lastName).trim();
+    }
+
+    default LocalDate toLocalDate(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return instant.atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+}

--- a/src/main/resources/db/migration/V39__add_feedback_table.sql
+++ b/src/main/resources/db/migration/V39__add_feedback_table.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS feedback (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    feedback TEXT,
+    rating NUMERIC(3, 2) NOT NULL DEFAULT 0,
+    patient_id UUID NOT NULL,
+    doctor_id UUID NOT NULL,
+    consultation_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ,
+    created_by UUID NOT NULL,
+    updated_by UUID,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_by VARCHAR(255),
+    deleted_at TIMESTAMPTZ,
+    CONSTRAINT uq_feedback_consultation UNIQUE (consultation_id),
+    CONSTRAINT fk_feedback_patient FOREIGN KEY (patient_id) REFERENCES patient (id),
+    CONSTRAINT fk_feedback_doctor FOREIGN KEY (doctor_id) REFERENCES doctor (id),
+    CONSTRAINT fk_feedback_consultation FOREIGN KEY (consultation_id) REFERENCES consultation (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_patient ON feedback (patient_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_doctor ON feedback (doctor_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_consultation ON feedback (consultation_id);

--- a/src/main/resources/db/migration/V40__alter_feedback_rating_type.sql
+++ b/src/main/resources/db/migration/V40__alter_feedback_rating_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feedback
+    ALTER COLUMN rating TYPE DOUBLE PRECISION USING rating::double precision;

--- a/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
+++ b/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Profile;
 
 import com.cloudinary.Cloudinary;
 import com.cloudinary.Uploader;
-import com.nexaworks.rafiq.config.FirebaseConfig;
 import com.nexaworks.rafiq.scheduler.ExpirationScheduler;
 import com.nexaworks.rafiq.service.call.RtcProvider;
 
@@ -50,11 +49,7 @@ public class IntegrationTestExternalMocks {
     public ExpirationScheduler expirationSchedulerMock() {
         return Mockito.mock(ExpirationScheduler.class);
     }
-    @Bean
-    @Primary
-    public FirebaseConfig firebaseConfig() {
-        return Mockito.mock(FirebaseConfig.class);
-    }
+
     @Bean
     @Primary
     public RedissonClient redissonClient() {

--- a/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
+++ b/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Profile;
 
 import com.cloudinary.Cloudinary;
 import com.cloudinary.Uploader;
+import com.nexaworks.rafiq.config.FirebaseConfig;
 import com.nexaworks.rafiq.scheduler.ExpirationScheduler;
 import com.nexaworks.rafiq.service.call.RtcProvider;
 
@@ -47,5 +48,10 @@ public class IntegrationTestExternalMocks {
     @Primary
     public ExpirationScheduler expirationSchedulerMock() {
         return Mockito.mock(ExpirationScheduler.class);
+    }
+    @Bean
+    @Primary
+    public FirebaseConfig firebaseConfig() {
+        return Mockito.mock(FirebaseConfig.class);
     }
 }

--- a/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
+++ b/src/test/java/com/nexaworks/rafiq/integration/config/IntegrationTestExternalMocks.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -53,5 +54,10 @@ public class IntegrationTestExternalMocks {
     @Primary
     public FirebaseConfig firebaseConfig() {
         return Mockito.mock(FirebaseConfig.class);
+    }
+    @Bean
+    @Primary
+    public RedissonClient redissonClient() {
+        return Mockito.mock(RedissonClient.class);
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -11,6 +11,18 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
   main:
     allow-bean-definition-overriding: true
+  jpa:
+    properties:
+      hibernate:
+        cache:
+          use_second_level_cache: false
+          use_query_cache: false
+          region:
+            factory_class: org.hibernate.cache.internal.NoCachingRegionFactory
+        format_sql: false
+        use_sql_comments: false
+    hibernate:
+      ddl-auto: create-drop
 
   cache:
     type: none
@@ -28,13 +40,7 @@ spring:
       connection-timeout: 10000
       idle-timeout: 30000
 
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        format_sql: false
-        use_sql_comments: false
+
 
   flyway:
     enabled: false

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -8,6 +8,9 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+  main:
+    allow-bean-definition-overriding: true
 
   cache:
     type: none


### PR DESCRIPTION
This pull request introduces a new in-house idempotency mechanism for the application, replacing the previous third-party solution. The main changes include the implementation of custom idempotency annotations, filters, configuration, and storage backends (both in-memory and Redis). The codebase has been refactored to use the new annotation and supporting infrastructure throughout all relevant controllers.

**Idempotency Infrastructure Implementation**

* Added a custom `@Idempotent` annotation in `com.nexaworks.rafiq.idempotency.annotation` to mark controller methods that require idempotency handling.
* Implemented idempotency filters: `IdempotencyFilter` (as a Spring `HandlerInterceptor`) to intercept requests and enforce idempotency, and `WrapperFilter` to cache responses for idempotent requests. [[1]](diffhunk://#diff-8b630952e5d21bd56924cfa5aec7c5dfc96b43d658c64d86febb518ac9dec936R1-R67) [[2]](diffhunk://#diff-1627aa8bd62814553053856b40edd225d6653dcdb489ad6353fca6176539abadR1-R47)
* Introduced `IdempotencyStore` interface and two storage implementations: `InMemoryIdempotencyStore` and `RedisIdempotencyStore` (the latter via configuration), along with the supporting `IdempotentResponse` record and status handling. [[1]](diffhunk://#diff-0392898ca35264fb6552cf71d17c8018855b5560e7eb78116df2c0db725209a4R1-R10) [[2]](diffhunk://#diff-a5c812c2654d5332206a886a00677edd63391b7c14d324891ec98027df4b1271R1-R45) [[3]](diffhunk://#diff-24c2e8ccfde7f6d907fc2eacaddd06b9d58e8daac31bf7e4be18c5c266f66cceR1-R18) [[4]](diffhunk://#diff-73d64a55ded8540cf5726be70e17c97ba754f91be14af73a0174f4fd162c9e7dR1-R41)
* Added configuration classes (`IdempotencyConfiguration`, `RedisIdempotencyConfiguration`, and `IdempotencyProperties`) to wire up the idempotency system and allow for flexible backend selection and property configuration. [[1]](diffhunk://#diff-d57afa872edaac28a6e6d27d0036e6f4205897d60cb78e647f69103d28a57135R1-R43) [[2]](diffhunk://#diff-73d64a55ded8540cf5726be70e17c97ba754f91be14af73a0174f4fd162c9e7dR1-R41) [[3]](diffhunk://#diff-a70b9c3d1bf15fe9330fddefca3b20704de5803d60221b77c55f264b94e50489R1-R37)
* Added a custom exception `RequestInFlightException` to handle concurrent in-flight idempotent requests.

**Codebase Refactoring for In-House Idempotency**

* Removed the dependency on the external `idempotency-spring-boot-starter` library from `pom.xml`.
* Updated all controller imports to use the new in-house `@Idempotent` annotation instead of the previous third-party annotation. [[1]](diffhunk://#diff-cc9af79d28272b0c66466a6a36345f8dd5db3a49861dbeffec4de15e6ceb102eR13-L15) [[2]](diffhunk://#diff-b46625ee3ee05af1f21ad6f44cb222f4b75718fcb7d743fa96346260cf1690aeR19-L23) [[3]](diffhunk://#diff-8e1711b18e23a2abae5480ceaebc30e2f7f26a2bc68359dc5fb81bfd7b38f6bcR20-L24) [[4]](diffhunk://#diff-fdb14be384b4058cc95fd7d67a96a0543ac575aa78182a9fbccb303589c80c23R16-L18) [[5]](diffhunk://#diff-4d2187a2bd397334c3fea6aca899f144772d67828f75c714a920bf2f69c7309cR20-L23) [[6]](diffhunk://#diff-fe6cb760db89e1b9a0bd36f2c6da5d5ac3ac6e19c4462415d2fad7473922b866R19-L21) [[7]](diffhunk://#diff-b4bc89771eb84c1498b4fa2d62c66cfdae99e07f14233a98c5c713b75d6d8d76R22-L24) [[8]](diffhunk://#diff-105100f38e3d0ce4b5a9da84eecd065bfe6faa91797e38efbdc3d6e82b56209cR16-L19)
* Registered the new idempotency configuration properties in the main application class (`RafiqApplication`).