### PR TITLE
Fix/hot fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.nexaworks</groupId>
 	<artifactId>rafiq</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<name>rafiq</name>
 	<description>Health Care App</description>
 	<url/>

--- a/src/main/java/com/nexaworks/rafiq/scheduler/JobRunrExpirationScheduler.java
+++ b/src/main/java/com/nexaworks/rafiq/scheduler/JobRunrExpirationScheduler.java
@@ -1,9 +1,12 @@
 package com.nexaworks.rafiq.scheduler;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.jobrunr.jobs.Job;
 import org.jobrunr.scheduling.BackgroundJob;
+import org.jobrunr.storage.StorageProvider;
 import org.springframework.stereotype.Component;
 
 import com.nexaworks.rafiq.service.consultation.IConsultationSlotExpirationService;
@@ -16,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class JobRunrExpirationScheduler implements ExpirationScheduler {
     private final IConsultationSlotExpirationService consultationSlotExpirationService;
+    private final StorageProvider storageProvider;
     @Override
     public void scheduleConsultationSlotExpiration(UUID consultationSlotId, LocalDateTime endTime) {
         log.info("Scheduling consultation slot expiration for slot: {}", consultationSlotId);
@@ -32,7 +36,11 @@ public class JobRunrExpirationScheduler implements ExpirationScheduler {
     @Override
     public void reSchedule(UUID id, LocalDateTime endTime) {
         log.info("Rescheduling expiration job for slot: {}", id);
-        deleteExpirationJob(id);
-        scheduleConsultationSlotExpiration(id, endTime);
+        Job job = storageProvider.getJobById(id);
+        if (job != null) {
+            job.scheduleAt(Instant.from(endTime), "user edit slot endTime");
+        }
+        // deleteExpirationJob(id);
+        // scheduleConsultationSlotExpiration(id, endTime);
     }
 }

--- a/src/main/java/com/nexaworks/rafiq/scheduler/JobRunrExpirationScheduler.java
+++ b/src/main/java/com/nexaworks/rafiq/scheduler/JobRunrExpirationScheduler.java
@@ -1,7 +1,7 @@
 package com.nexaworks.rafiq.scheduler;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
 
 import org.jobrunr.jobs.Job;
@@ -38,7 +38,8 @@ public class JobRunrExpirationScheduler implements ExpirationScheduler {
         log.info("Rescheduling expiration job for slot: {}", id);
         Job job = storageProvider.getJobById(id);
         if (job != null) {
-            job.scheduleAt(Instant.from(endTime), "user edit slot endTime");
+            job.scheduleAt(endTime.atZone(ZoneId.systemDefault()).toInstant(),
+                    "user edit slot endTime");
         }
         // deleteExpirationJob(id);
         // scheduleConsultationSlotExpiration(id, endTime);


### PR DESCRIPTION
This pull request updates the version of the project and refactors the `JobRunrExpirationScheduler` to improve how expiration jobs are rescheduled. The primary focus is on leveraging the `StorageProvider` to directly reschedule jobs, rather than deleting and recreating them.

**Version update:**

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L13-R13): Bumped the project version from `1.0.0` to `1.1.0`.

**Job rescheduling improvements:**

* [`JobRunrExpirationScheduler.java`](diffhunk://#diff-c37ae8d689e22bfe8410444d9668748627ad330a10c54f1e3ed0af62c1f352ecR22): Added a `StorageProvider` dependency to enable direct job management.
* [`JobRunrExpirationScheduler.java`](diffhunk://#diff-c37ae8d689e22bfe8410444d9668748627ad330a10c54f1e3ed0af62c1f352ecL35-R45): In the `reSchedule` method, replaced the previous delete-and-recreate logic with direct rescheduling using the `Job` object, improving efficiency and reducing unnecessary operations.
* [`JobRunrExpirationScheduler.java`](diffhunk://#diff-c37ae8d689e22bfe8410444d9668748627ad330a10c54f1e3ed0af62c1f352ecR4-R9): Added necessary imports for `ZoneId`, `Job`, and `StorageProvider` to support the new scheduling logic.